### PR TITLE
Map dictionary fix and new options

### DIFF
--- a/BobbysMusicPlayer.csproj
+++ b/BobbysMusicPlayer.csproj
@@ -79,6 +79,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConfigurationManagerAttributes.cs" />
+    <Compile Include="Patches\HeadsetPatch.cs" />
     <Compile Include="Patches\CombatMusicPatch.cs" />
     <Compile Include="Patches\UISoundsPatch.cs" />
     <Compile Include="Patches\MenuMusicPatch.cs" />

--- a/Patches/HeadsetPatch.cs
+++ b/Patches/HeadsetPatch.cs
@@ -1,0 +1,41 @@
+﻿using Comfort.Common;
+using EFT;
+using EFT.InventoryLogic;
+using HarmonyLib;
+using SPT.Reflection.Patching;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Remoting.Messaging;
+using UnityEngine;
+using HeadsetClass = GClass2654;
+
+namespace BobbysMusicPlayer.Patches
+{
+    public class HeadsetPatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            return AccessTools.Method(typeof(Player), nameof(Player.UpdatePhones));
+        }
+
+        [PatchPostfix]
+        private static void Postfix(Player __instance)
+        {
+            if (__instance == Singleton<GameWorld>.Instance.MainPlayer)
+            {
+                EquipmentClass equipment = __instance.Equipment;
+                LootItemClass headwear = equipment.GetSlot(EquipmentSlot.Headwear).ContainedItem as LootItemClass;
+                HeadsetClass headset = (equipment.GetSlot(EquipmentSlot.Earpiece).ContainedItem as HeadsetClass) ?? ((headwear != null) ? headwear.GetAllItemsFromCollection().OfType<HeadsetClass>().FirstOrDefault<HeadsetClass>() : null);
+                if (headset != null)
+                {
+                    Plugin.headsetMultiplier = Plugin.HeadsetMultiplier.Value;
+                }
+                else
+                {
+                    Plugin.headsetMultiplier = 1f;
+                }
+            }
+        }
+    }
+}

--- a/Patches/MenuMusicPatch.cs
+++ b/Patches/MenuMusicPatch.cs
@@ -21,14 +21,13 @@ namespace BobbysMusicPlayer.Patches
         private static List<string> trackListToPlay = new List<string>();
         private static List<string> trackNamesArray = new List<string>();
         internal static bool HasReloadedAudio = false;
-        Plugin plugin = new Plugin();
 
         protected override MethodBase GetTargetMethod()
         {
             return AccessTools.Method(typeof(GUISounds), nameof(GUISounds.method_3));
         }
 
-        internal async void LoadAudioClips()
+        internal static async void LoadAudioClips()
         {
             float totalLength = 0;
             HasReloadedAudio = true;
@@ -46,6 +45,7 @@ namespace BobbysMusicPlayer.Patches
                 int nextRandom = Plugin.rand.Next(trackListToPlay.Count);
                 string track = trackListToPlay[nextRandom];
                 string trackPath = Path.GetFileName(track);
+                Plugin plugin = new Plugin();
                 AudioClip unityAudioClip = await plugin.AsyncRequestAudioClip(track);
                 trackArray.Add(unityAudioClip);
                 trackNamesArray.Add(trackPath);


### PR DESCRIPTION
Indoor volume multiplier now applies to all in-raid music.
Added a configurable active headset multiplier for in-raid music. Plugin no longer creates a MenuMusicPatch object, and MenuMusicPatch no longer creates a Plugin object. Tidied up Plugin.CombatMusic.
Moved call of Plugin.VolumeSetter further down in Plugin.Update so that certain "if" statements are no longer necessary. Added support for more audio types.
Fixed some maps not loading their soundtracks properly.